### PR TITLE
add the queue name processed by the worker in the 'queue' key

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -120,6 +120,7 @@ TWorker.prototype.process = function (cb) {
     ping: this.ping,
     sleep: this.sleep,
     type: this.type,
+    queue: this.queue.name,
     taskCount: this.taskCount,
     status: 'waiting'
   }, this.loop.bind(this));

--- a/test/worker.js
+++ b/test/worker.js
@@ -187,6 +187,7 @@ describe('Taskman worker', function () {
           expect(infos).to.have.property('ping', '1000');
           expect(infos).to.have.property('sleep', '0');
           expect(infos).to.have.property('type', 'fifo');
+          expect(infos).to.have.property('queue', 'test');
           expect(infos).to.have.property('taskCount', '1');
           expect(infos).to.have.property('status', 'working');
           next();


### PR DESCRIPTION
It's usefull to know the queue processed by a worker with a simple redis command like hgetall.
So I store the queue name in the 'queue' key in the redis hash of the worker.
